### PR TITLE
feat(client): component class

### DIFF
--- a/packages/client/src/lib/component.ts
+++ b/packages/client/src/lib/component.ts
@@ -1,0 +1,23 @@
+export abstract class Component<Props extends {}> {
+  private props: Props
+  private element: HTMLElement
+
+  constructor(props: Props) {
+    this.props = props
+    this.element = this.render(props)
+  }
+
+  abstract render(props: Props): HTMLElement
+
+  mount(parent: HTMLElement) {
+    parent.appendChild(this.element)
+  }
+
+  update(updatedProps: Partial<Props>) {
+    this.props = { ...this.props, ...updatedProps }
+    const updatedElement = this.render(this.props)
+
+    this.element.replaceWith(updatedElement)
+    this.element = updatedElement
+  }
+}


### PR DESCRIPTION
closes #143 

- create base component class

### example usage
```ts
type Props = {
  text: string
  onClick?: () => void
}

export class Button extends Component<Props> {
  render({ text, onClick }: Props) {
    const button = document.createElement('button')
    button.innerText = text

    if (onClick) {
      button.addEventListener('click', onClick)
    }

    return button
  }
}
```