### PR TITLE
feat: create `Toaster` component

### DIFF
--- a/packages/client/src/components/header.ts
+++ b/packages/client/src/components/header.ts
@@ -22,7 +22,7 @@ export class Header extends Component {
 
     const header = element('header', {
       className:
-        'fixed z-50 w-full flex justify-between items-center max-w-5xl px-4 h-header-sm bg-slate-50/80 backdrop-blur-xs md:h-header-md',
+        'fixed z-40 w-full flex justify-between items-center max-w-5xl px-4 h-header-sm bg-slate-50/80 backdrop-blur-xs md:h-header-md',
       children: [logo, button.element],
     })
 

--- a/packages/client/src/components/toaster.ts
+++ b/packages/client/src/components/toaster.ts
@@ -1,0 +1,64 @@
+import { AlertCircle, createElement } from 'lucide'
+import { Component } from '../core/component'
+import { element } from '../utils/element'
+import { cn } from '../utils/classnames'
+
+export class Toaster extends Component<
+  {},
+  {
+    messages: { id: number; message: string }[]
+  }
+> {
+  private static instance: Toaster
+  private id = 0
+
+  constructor() {
+    super({ state: { messages: [] } })
+    Toaster.instance = this
+  }
+
+  static show(message: string) {
+    const instance = Toaster.instance
+    if (!instance) throw new Error('toaster is not mounted yet')
+
+    const id = instance.id++
+    instance.setState({
+      messages: [...instance.state.messages, { id, message }],
+    })
+
+    setTimeout(() => {
+      instance.setState({
+        messages: instance.state.messages.filter(
+          (message) => message.id !== id
+        ),
+      })
+    }, 3000)
+  }
+
+  render() {
+    const wrapper = element('div', {
+      className: cn([
+        'fixed z-50 flex gap-2 flex-col',
+        'top-header-sm pt-3 left-4 right-4',
+        'md:pt-0 md:left-auto md:top-auto md:right-6 md:bottom-6',
+      ]),
+    })
+
+    for (const { message } of this.state.messages) {
+      const toast = element('div', {
+        className: cn([
+          'flex gap-2 items-center py-3 pl-4 pr-6 min-w-80 max-w-sm rounded-full',
+          'bg-white border border-warning-bright text-warning-bright font-sm shadow-float',
+        ]),
+        children: [
+          createElement(AlertCircle, { class: 'size-4 shrink-0' }),
+          element('span', { innerText: message }),
+        ],
+      })
+
+      wrapper.appendChild(toast)
+    }
+
+    return wrapper
+  }
+}

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,3 +1,4 @@
+import { Toaster } from './components/toaster'
 import { Router } from './core/router'
 import { UnauthenticatedLayout } from './layouts/unauthenticated'
 import { ExplorePage } from './pages/explore'
@@ -21,3 +22,6 @@ export const router = new Router({
   outletSelector: '#app',
   notFoundHandler: () => new TemporaryPage(),
 })
+
+const toaster = new Toaster()
+toaster.mount(document.body)

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -11,6 +11,8 @@
 
   --spacing-header-sm: calc(var(--spacing) * 16);
   --spacing-header-md: calc(var(--spacing) * 20);
+
+  --shadow-float: 0 8px 32px #27272a1f;
 }
 
 @layer base {


### PR DESCRIPTION
closes #123 

- create toaster component
- removes the toast after 3 seconds
- can stack toasts
- mount it to the body

### usage
```ts
Toaster.show('my error message')
```