### PR TITLE
feat(client): register page

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       "name": "@repo/client",
       "version": "0.0.0",
       "dependencies": {
+        "@repo/validation": "workspace:*",
         "@tailwindcss/vite": "^4.1.2",
         "axios": "^1.8.4",
         "class-variance-authority": "^0.7.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "vite": "^6.2.0"
   },
   "dependencies": {
+    "@repo/validation": "workspace:*",
     "@tailwindcss/vite": "^4.1.2",
     "axios": "^1.8.4",
     "class-variance-authority": "^0.7.1",

--- a/packages/client/src/components/register-form.ts
+++ b/packages/client/src/components/register-form.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod'
+
+import { registerSchema } from '@repo/validation/actions'
+import { ComponentWithMutation } from '../core/component'
+import { element } from '../utils/element'
+import { client } from '../lib/client'
+import { router } from '../main'
+import { Button } from '../components/button'
+import { Input } from '../components/input'
+import { Toaster } from '../components/toaster'
+
+const schema = registerSchema
+  .merge(z.object({ confirm: z.string() }))
+  .refine(({ password, confirm }) => password === confirm, {
+    message: 'passwords do not match',
+    path: ['confirm'],
+  })
+
+type RegisterValues = z.infer<typeof schema>
+
+export class RegisterForm extends ComponentWithMutation<RegisterValues> {
+  constructor() {
+    super({})
+  }
+
+  protected schema = () => schema
+
+  protected async mutation(values: RegisterValues) {
+    await client.post('/auth/register', values)
+    router.navigate('/')
+  }
+
+  protected onError(message: string) {
+    Toaster.show(message)
+  }
+
+  render() {
+    const username = new Input({
+      label: 'Username',
+      name: 'username',
+      value: this.values.username || '',
+      error: this.validationErrors?.username?._errors[0],
+    })
+
+    const email = new Input({
+      label: 'Email',
+      name: 'email',
+      type: 'email',
+      value: this.values.email || '',
+      error: this.validationErrors?.email?._errors[0],
+    })
+
+    const password = new Input({
+      label: 'Password',
+      name: 'password',
+      type: 'password',
+      value: this.values.password || '',
+      error: this.validationErrors?.password?._errors[0],
+    })
+
+    const confirm = new Input({
+      label: 'Confirm password',
+      name: 'confirm',
+      type: 'password',
+      value: this.values.confirm || '',
+      error: this.validationErrors?.confirm?._errors[0],
+    })
+
+    const button = new Button({
+      label: 'Create account',
+    })
+
+    const inputs = element('div', {
+      className: 'flex flex-col gap-6',
+      children: [
+        username.element,
+        email.element,
+        password.element,
+        confirm.element,
+      ],
+    })
+
+    const form = element('form', {
+      on: {
+        submit: (event: SubmitEvent) => {
+          event.preventDefault()
+
+          const formData = new FormData(form)
+          const values = Object.fromEntries(formData.entries())
+
+          this.mutate(values)
+        },
+      },
+      className: 'flex flex-col gap-8 w-full',
+      children: [inputs, button.element],
+    })
+
+    return form
+  }
+}

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -2,6 +2,7 @@ import { Toaster } from './components/toaster'
 import { Router } from './core/router'
 import { UnauthenticatedLayout } from './layouts/unauthenticated'
 import { ExplorePage } from './pages/explore'
+import { RegisterPage } from './pages/register'
 import { TemporaryPage } from './pages/temporary'
 import './style.css'
 
@@ -16,7 +17,10 @@ export const router = new Router({
     '/capsule/edit': () => new TemporaryPage(),
     '/profile': () => new TemporaryPage(),
     '/profile/edit': () => new TemporaryPage(),
-    '/auth/register': () => new TemporaryPage(),
+    '/auth/register': () =>
+      new UnauthenticatedLayout({
+        children: [new RegisterPage().element],
+      }),
     '/auth/log-in': () => new TemporaryPage(),
   },
   outletSelector: '#app',

--- a/packages/client/src/pages/register.ts
+++ b/packages/client/src/pages/register.ts
@@ -1,0 +1,41 @@
+import { Component } from '../core/component'
+import { element } from '../utils/element'
+import { RegisterForm } from '../components/register-form'
+
+export class RegisterPage extends Component {
+  constructor() {
+    super({})
+  }
+
+  render() {
+    const message = element('h1', {
+      className: 'space-x-2 text-2xl',
+      children: [
+        element('span', { innerText: 'Welcome to' }),
+        element('span', { innerText: 'echo', className: 'font-black' }),
+        element('span', { innerText: '!' }),
+      ],
+    })
+
+    const link = element('a', {
+      href: '/auth/login',
+      className: 'text-sm hover:underline',
+      children: [
+        element('span', { innerText: 'Already have an account?' }),
+        element('span', { innerText: ' Log in', className: 'font-bold' }),
+      ],
+    })
+
+    return element('main', {
+      className:
+        'grow w-full max-w-xl flex flex-col items-center gap-6 md:gap-2 px-4 pt-header-sm mb-6 mt-4 md:pt-header-md md:mb-8',
+      children: [
+        element('div', {
+          className: 'grow w-full flex flex-col items-center mt-[10vh] gap-8',
+          children: [message, new RegisterForm().element],
+        }),
+        link,
+      ],
+    })
+  }
+}

--- a/packages/client/src/utils/element.ts
+++ b/packages/client/src/utils/element.ts
@@ -4,17 +4,29 @@ export const element = <Tag extends keyof HTMLElementTagNameMap>(
   tag: Tag,
   options?: Partial<Omit<HTMLElementTagNameMap[Tag], 'children'>> & {
     children?: Child[]
+    on?: {
+      [K in keyof HTMLElementEventMap]?: (event: HTMLElementEventMap[K]) => void
+    }
   }
 ): HTMLElementTagNameMap[Tag] => {
   const element = document.createElement(tag)
   if (!options) return element
 
-  const { children, ...attributes } = options
+  const { children, on, ...attributes } = options
   Object.assign(element, attributes)
 
-  if (!children) return element
+  if (children) {
+    appendChildren(element, children)
+  }
 
-  return appendChildren(element, children)
+  if (on) {
+    for (const type in on) {
+      const listener = on[type as keyof HTMLElementEventMap]!
+      element.addEventListener(type, listener as EventListener)
+    }
+  }
+
+  return element
 }
 
 export const appendChildren = <Parent extends Element>(

--- a/packages/server/models/user.ts
+++ b/packages/server/models/user.ts
@@ -15,12 +15,10 @@ const schema = new Schema(
     },
     firstName: {
       type: String,
-      required: true,
       trim: true,
     },
     lastName: {
       type: String,
-      required: true,
       trim: true,
     },
     email: {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,6 +4,7 @@
     "dev": "bun --hot run api/index.ts"
   },
   "dependencies": {
+    "@repo/validation": "workspace:*",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
@@ -13,7 +14,6 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.13.1",
     "multer": "^1.4.5-lts.1",
-    "@repo/validation": "workspace:*",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/packages/validation/src/actions.ts
+++ b/packages/validation/src/actions.ts
@@ -4,8 +4,8 @@ import { imageSchema, passwordSchema, usernameSchema } from './partials'
 
 export const registerSchema = z.object({
   username: usernameSchema,
-  firstName: z.string(),
-  lastName: z.string(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
   email: z.string().email(),
   password: passwordSchema,
   image: imageSchema.optional(),


### PR DESCRIPTION
closes #138 

- create `RegisterForm` and `RegisterPage`
- create `ComponentWithMutation` that supports loading state, validation and validation errors, general error handling with `this.error` and `onError`
- update `element` to support easily creating event listeners
- make `firstName` and `lastName` optional