### PR TITLE
feat(server): include user in the capsule response

### DIFF
--- a/packages/server/models/capsule.ts
+++ b/packages/server/models/capsule.ts
@@ -1,26 +1,6 @@
 import { Document, InferSchemaType, model, Schema, Types } from 'mongoose'
 
 import { imageSchema } from '../schemas/image'
-import { z } from 'zod'
-
-const sealValidation = {
-  validator: () => {
-    const schema = z
-      .object({
-        sealedAt: z.date().optional(),
-        openDate: z.date().optional(),
-      })
-      .refine((data) => {
-        return (
-          (data.sealedAt && data.openDate) || (!data.sealedAt && !data.openDate)
-        )
-      })
-
-    const { success } = schema.safeParse(this)
-    return success
-  },
-  message: 'document must have either both sealedAt and openDate, or neither',
-}
 
 const schema = new Schema(
   {
@@ -31,11 +11,9 @@ const schema = new Schema(
     },
     sealedAt: {
       type: Date,
-      validate: sealValidation,
     },
     openDate: {
       type: Date,
-      validate: sealValidation,
     },
     showCountdown: {
       type: Boolean,

--- a/packages/validation/src/data.ts
+++ b/packages/validation/src/data.ts
@@ -6,11 +6,23 @@ export const tokenResponseSchema = z.object({
   accessToken: z.string(),
 })
 
+const image = z.object({
+  name: z.string(),
+  type: z.string(),
+})
+
+const user = z.object({
+  username: z.string(),
+  firstName: z.string(),
+  lastName: z.string(),
+  image,
+})
+
 const capsule = z.object({
   id,
   visibility: z.enum(['public', 'private']),
-  senders: z.array(id),
-  receivers: z.array(id),
+  senders: z.array(user).nonempty(),
+  receivers: z.array(user),
 })
 
 const unsealedCapsule = capsule.merge(
@@ -19,17 +31,12 @@ const unsealedCapsule = capsule.merge(
     showCountdown: z.boolean(),
     title: z.string(),
     content: z.string().optional(),
-    images: z.array(
-      z.object({
-        name: z.string(),
-        type: z.string(),
-      })
-    ),
+    images: z.array(image),
   })
 )
 
 const sealedCapsule = capsule.merge(
-  z.object({ state: z.literal('sealed'), openDate: z.date() })
+  z.object({ state: z.literal('sealed'), openDate: z.coerce.date() })
 )
 
 const openedCapsule = capsule.merge(
@@ -43,8 +50,8 @@ const openedCapsule = capsule.merge(
         type: z.string(),
       })
     ),
-    openDate: z.date(),
-    sealedAt: z.date(),
+    openDate: z.coerce.date(),
+    sealedAt: z.coerce.date(),
   })
 )
 


### PR DESCRIPTION
- include user in capsule response
- update validation
  - fix coercion of dates
- fix schema validation
  - you couldn't create capsules with an `openDate` because the schema validation was running before the `pre('save')` added the `sealDate`