### PR TITLE
feat(client): explore page

### DIFF
--- a/packages/client/src/components/skeleton.ts
+++ b/packages/client/src/components/skeleton.ts
@@ -1,0 +1,24 @@
+import { Component } from '../core/component'
+import { cn } from '../utils/classnames'
+import { element } from '../utils/element'
+
+type Props = {
+  className: string
+}
+
+export class Skeleton extends Component<Props> {
+  constructor(props?: Props) {
+    super({ props })
+  }
+
+  render() {
+    const { className } = this.props
+
+    return element('div', {
+      className: cn(
+        'shrink-0 bg-slate-200 w-full rounded-3xl animate-pulse',
+        className
+      ),
+    })
+  }
+}

--- a/packages/client/src/components/tabs.ts
+++ b/packages/client/src/components/tabs.ts
@@ -20,7 +20,7 @@ export class Tabs extends Component<Props> {
 
     const div = element('div', {
       className:
-        'fixed bottom-8 flex gap-2 p-1 bg-white rounded-full shadow-float',
+        'fixed z-40 bottom-8 flex gap-2 p-1 bg-white rounded-full shadow-float',
     })
 
     tabs.forEach(({ label, href, isActive }) => {

--- a/packages/client/src/components/tabs.ts
+++ b/packages/client/src/components/tabs.ts
@@ -1,0 +1,40 @@
+import { Component } from '../core/component'
+import { element } from '../utils/element'
+import { cn } from '../utils/classnames'
+
+type Props = {
+  tabs: {
+    label: string
+    href: string
+    isActive: boolean
+  }[]
+}
+
+export class Tabs extends Component<Props> {
+  constructor(props: Props) {
+    super({ props })
+  }
+
+  render() {
+    const { tabs } = this.props
+
+    const div = element('div', {
+      className:
+        'fixed bottom-8 flex gap-2 p-1 bg-white rounded-full shadow-float',
+    })
+
+    tabs.forEach(({ label, href, isActive }) => {
+      const a = element('a', {
+        innerText: label,
+        href,
+        className: cn(
+          'py-2 px-3 text-xs text-zinc-600 bg-white rounded-full transition hover:bg-slate-100',
+          isActive && 'bg-slate-800 text-white hover:bg-slate-700'
+        ),
+      })
+      div.appendChild(a)
+    })
+
+    return div
+  }
+}

--- a/packages/client/src/core/component.ts
+++ b/packages/client/src/core/component.ts
@@ -50,7 +50,7 @@ export abstract class ComponentWithData<
   Data,
   Props extends {} = {},
   State extends {} = {},
-> extends Component<Props, State> {
+> extends Base<Props, State> {
   protected data: Data | null = null
   protected isLoading = true
   protected error: string | null = null

--- a/packages/client/src/pages/explore.ts
+++ b/packages/client/src/pages/explore.ts
@@ -50,9 +50,15 @@ export class ExplorePage extends ComponentWithData<CapsuleData[]> {
 
     // TODO: display loader
 
-    if (!this.data) {
-      // TODO: display error
-      return element('main', { innerText: 'error' })
+    if (!this.data || this.data.length === 0) {
+      const error = element('div', {
+        className: 'mt-[20vh] text-center text-xl font-bold',
+        innerText:
+          'Oops! The capsule vault is empty. The time travelers must be running late!',
+      })
+      main.appendChild(error)
+
+      return main
     }
 
     this.data.forEach((capsule) => {

--- a/packages/client/src/pages/explore.ts
+++ b/packages/client/src/pages/explore.ts
@@ -1,12 +1,55 @@
-import { Component } from '../core/component'
-import { element } from '../utils/element'
+import { z } from 'zod'
 
-export class ExplorePage extends Component {
+import { CapsuleData, capsuleResponseSchema } from '@repo/validation/data'
+import { ComponentWithData } from '../core/component'
+import { element } from '../utils/element'
+import { client } from '../lib/client'
+import { Capsule } from '../components/capsule'
+import { getImageUrl } from '../utils/get-image-url'
+
+const schema = z.array(capsuleResponseSchema)
+
+export class ExplorePage extends ComponentWithData<CapsuleData[]> {
   constructor() {
     super({})
   }
 
+  protected schema = () => schema
+
+  protected async query() {
+    return await client.get(`/capsules/public`)
+  }
+
   render() {
-    return element('main', { innerText: 'explore', className: 'w-full' })
+    const main = element('main', {
+      className: 'main-unauthenticated max-w-md gap-6',
+    })
+
+    // TODO: display loader
+
+    if (!this.data) {
+      // TODO: display error
+      return element('main', { innerText: 'error' })
+    }
+
+    this.data.forEach((capsule) => {
+      if (capsule.state === 'opened') {
+        const c = new Capsule({
+          id: capsule.id,
+          title: capsule.title,
+          image: getImageUrl({
+            type: 'capsule',
+            capsuleId: capsule.id,
+            imageName: capsule.images[0]?.name,
+          }),
+          openDate: capsule.openDate,
+          senders: capsule.senders,
+        })
+
+        c.mount(main)
+      }
+    })
+
+    return main
   }
 }

--- a/packages/client/src/pages/explore.ts
+++ b/packages/client/src/pages/explore.ts
@@ -6,8 +6,15 @@ import { element } from '../utils/element'
 import { client } from '../lib/client'
 import { Capsule } from '../components/capsule'
 import { getImageUrl } from '../utils/get-image-url'
+import { Countdown } from '../components/countdown'
+import { Tabs } from '../components/tabs'
 
 const schema = z.array(capsuleResponseSchema)
+
+const getType = () => {
+  const params = new URLSearchParams(window.location.search)
+  return params.get('type') || 'opened'
+}
 
 export class ExplorePage extends ComponentWithData<CapsuleData[]> {
   constructor() {
@@ -17,12 +24,28 @@ export class ExplorePage extends ComponentWithData<CapsuleData[]> {
   protected schema = () => schema
 
   protected async query() {
-    return await client.get(`/capsules/public`)
+    return await client.get(`/capsules/public?type=${getType()}`)
   }
 
   render() {
     const main = element('main', {
       className: 'main-unauthenticated max-w-md gap-6',
+      children: [
+        new Tabs({
+          tabs: [
+            {
+              label: 'Opened',
+              href: '/?type=opened',
+              isActive: getType() === 'opened',
+            },
+            {
+              label: 'Sealed',
+              href: '/?type=sealed',
+              isActive: getType() === 'sealed',
+            },
+          ],
+        }).element,
+      ],
     })
 
     // TODO: display loader
@@ -45,7 +68,9 @@ export class ExplorePage extends ComponentWithData<CapsuleData[]> {
           openDate: capsule.openDate,
           senders: capsule.senders,
         })
-
+        c.mount(main)
+      } else if (capsule.state === 'sealed') {
+        const c = new Countdown({ id: capsule.id, openDate: capsule.openDate })
         c.mount(main)
       }
     })

--- a/packages/client/src/pages/explore.ts
+++ b/packages/client/src/pages/explore.ts
@@ -8,6 +8,8 @@ import { Capsule } from '../components/capsule'
 import { getImageUrl } from '../utils/get-image-url'
 import { Countdown } from '../components/countdown'
 import { Tabs } from '../components/tabs'
+import { Skeleton } from '../components/skeleton'
+import { cn } from '../utils/classnames'
 
 const schema = z.array(capsuleResponseSchema)
 
@@ -29,7 +31,10 @@ export class ExplorePage extends ComponentWithData<CapsuleData[]> {
 
   render() {
     const main = element('main', {
-      className: 'main-unauthenticated max-w-md gap-6',
+      className: cn(
+        'main-unauthenticated max-w-md gap-6',
+        this.isLoading && 'h-[80vh] overflow-hidden mb-0'
+      ),
       children: [
         new Tabs({
           tabs: [
@@ -48,7 +53,11 @@ export class ExplorePage extends ComponentWithData<CapsuleData[]> {
       ],
     })
 
-    // TODO: display loader
+    if (this.isLoading) {
+      new Skeleton({ className: 'h-96' }).mount(main)
+      new Skeleton({ className: 'h-96' }).mount(main)
+      return main
+    }
 
     if (!this.data || this.data.length === 0) {
       const error = element('div', {

--- a/packages/client/src/pages/log-in.ts
+++ b/packages/client/src/pages/log-in.ts
@@ -27,8 +27,7 @@ export class LogInPage extends Component {
     })
 
     return element('main', {
-      className:
-        'grow w-full max-w-xl flex flex-col items-center gap-6 md:gap-2 px-4 pt-header-sm mb-6 mt-4 md:pt-header-md md:mb-8',
+      className: 'main-unauthenticated max-w-xl gap-6 md:gap-2',
       children: [
         element('div', {
           className: 'grow w-full flex flex-col items-center mt-[10vh] gap-8',

--- a/packages/client/src/pages/register.ts
+++ b/packages/client/src/pages/register.ts
@@ -27,8 +27,7 @@ export class RegisterPage extends Component {
     })
 
     return element('main', {
-      className:
-        'grow w-full max-w-xl flex flex-col items-center gap-6 md:gap-2 px-4 pt-header-sm mb-6 mt-4 md:pt-header-md md:mb-8',
+      className: 'main-unauthenticated max-w-xl gap-6 md:gap-2',
       children: [
         element('div', {
           className: 'grow w-full flex flex-col items-center mt-[10vh] gap-8',

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -24,4 +24,8 @@
   *:focus-visible {
     @apply outline-1;
   }
+
+  .main-unauthenticated {
+    @apply grow w-full flex flex-col items-center px-4 pt-header-sm mb-6 mt-4 md:pt-header-md md:mb-8;
+  }
 }

--- a/packages/server/controller/image.ts
+++ b/packages/server/controller/image.ts
@@ -4,7 +4,7 @@ import type { Response } from 'express'
 import { User } from '../models/user'
 import { handle } from '../lib/handler'
 import { getBucketConnection, getFileId } from '../lib/file'
-import { HandlerError, NotFoundError, UnexpectedError } from '../lib/errors'
+import { HandlerError, NotFoundError } from '../lib/errors'
 import { objectIdSchema } from '../lib/validation'
 import { Capsule } from '../models/capsule'
 
@@ -21,19 +21,15 @@ const imageResponse = async ({
   const id = getFileId(name)
   const downloadStream = bucket.openDownloadStream(id)
 
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin')
   res.set('Content-Type', type)
 
   downloadStream.on('data', (chunk) => {
     res.write(chunk)
   })
 
-  downloadStream.on('error', (error) => {
-    throw new UnexpectedError(
-      error.message,
-      'something went wrong when downloading the image',
-      500,
-      'database_download_image',
-    )
+  downloadStream.on('error', () => {
+    res.status(404).end()
   })
 
   downloadStream.on('end', () => {

--- a/packages/validation/src/actions.ts
+++ b/packages/validation/src/actions.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod'
 
-import { image, password, username } from './partials'
+import { password, username } from './partials'
+
+const image = z.object({
+  name: z.string(),
+  type: z.string(),
+  size: z.number(),
+})
 
 export const registerActionSchema = z.object({
   username: username,
@@ -8,6 +14,7 @@ export const registerActionSchema = z.object({
   lastName: z.string().min(1).optional(),
   email: z.string().email(),
   password: password,
+  // TODO: the image will need to be updated because when sending the image from the client it will be a file
   image: image.optional(),
 })
 

--- a/packages/validation/src/partials.ts
+++ b/packages/validation/src/partials.ts
@@ -14,10 +14,4 @@ export const username = z
   .min(3, 'username must be at least 3 characters')
   .max(30, 'username cannot be longer than 30 characters')
 
-export const image = z.object({
-  name: z.string(),
-  type: z.string(),
-  size: z.number(),
-})
-
 export const id = z.coerce.string()


### PR DESCRIPTION
closes #131 and #132

- create `Skeleton` component
- create `Tabs` component
- create explore page:
  - tabs to switch between sealed and opened capsules
  - fetch capsule data
  - handle errors
  - loading state 