### PR TITLE
feat: capsule editor visibility page

### DIFF
--- a/packages/angular-client/src/app/layouts/capsule-editor.component.ts
+++ b/packages/angular-client/src/app/layouts/capsule-editor.component.ts
@@ -1,13 +1,10 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { startWith } from 'rxjs';
 import { ChevronLeft, X } from 'lucide-angular';
 
 import { CapsuleEditorService } from '../services/capsule-editor.service';
 import { HeaderComponent } from '../components/header.component';
 import { ButtonComponent } from '../components/button.component';
-
-const defaultTitle = 'Untitled capsule';
 
 @Component({
   selector: 'app-capsule-editor-layout',
@@ -23,15 +20,16 @@ const defaultTitle = 'Untitled capsule';
           (onClick)="capsuleEditor.back()"
         />
       }
-      <h1 class="font-bold text-center truncate">{{ title() }}</h1>
+      <h1 class="font-bold text-center truncate">
+        {{ capsuleEditor.title() }}
+      </h1>
     </app-header>
-    <main class="main">
+    <main class="main max-w-sm w-full">
       <router-outlet />
     </main>
   `,
 })
 export class CapsuleEditorLayoutComponent {
-  title = signal(defaultTitle);
   x = X;
   chevronLeft = ChevronLeft;
 
@@ -39,16 +37,5 @@ export class CapsuleEditorLayoutComponent {
 
   ngOnInit() {
     this.capsuleEditor.redirectToLastStep();
-
-    this.capsuleEditor.form.controls.title.valueChanges
-      .pipe(
-        startWith(this.capsuleEditor.form.controls.title.value || defaultTitle),
-      )
-      .subscribe((value) => {
-        if (!value) {
-          return this.title.set(defaultTitle);
-        }
-        this.title.set(value);
-      });
   }
 }

--- a/packages/angular-client/src/app/pages/capsule-wizard/content.component.ts
+++ b/packages/angular-client/src/app/pages/capsule-wizard/content.component.ts
@@ -15,35 +15,34 @@ import { ButtonComponent } from '../../components/button.component';
     ButtonComponent,
   ],
   template: `
-    <form [formGroup]="form" class="w-full max-w-sm flex flex-col gap-8">
+    <form [formGroup]="editor.form" class="flex flex-col gap-8">
       <div class="flex flex-col gap-6">
         <app-input
-          [control]="form.controls.title"
+          [control]="editor.form.controls.title"
           name="title"
           label="Title"
-          [error]="this.capsuleEditor.getValidationError('title')"
+          [error]="editor.getValidationError('title')"
         />
         <app-input
           [textarea]="true"
-          [control]="form.controls.content"
+          [control]="editor.form.controls.content"
           name="content"
           label="Content"
-          [error]="this.capsuleEditor.getValidationError('content')"
+          [error]="editor.getValidationError('content')"
         />
       </div>
       <app-upload-multiple
         name="images"
         label="Images"
-        (files)="capsuleEditor.images.set($event)"
+        (files)="editor.images.set($event)"
       />
     </form>
 
     <nav class="capsule-editor-navigation">
-      <app-button label="Next" (onClick)="capsuleEditor.next()" />
+      <app-button label="Next" (onClick)="editor.next()" />
     </nav>
   `,
 })
 export class ContentComponent {
-  capsuleEditor = inject(CapsuleEditorService);
-  form = this.capsuleEditor.form;
+  editor = inject(CapsuleEditorService);
 }

--- a/packages/angular-client/src/app/pages/capsule-wizard/visibility.component.ts
+++ b/packages/angular-client/src/app/pages/capsule-wizard/visibility.component.ts
@@ -1,15 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { CapsuleEditorService } from '../../services/capsule-editor.service';
+import { ButtonComponent } from '../../components/button.component';
 
 @Component({
   selector: 'app-visibility',
-  imports: [],
+  imports: [ButtonComponent, ReactiveFormsModule],
   template: `
-    <p>
-      visibility works!
-    </p>
+    <form [formGroup]="editor.form">
+      <h2 class="text-xl">
+        Will
+        <span class="font-bold">{{ editor.title() }}</span>
+        be publicly available?
+      </h2>
+
+      <nav class="capsule-editor-navigation">
+        <app-button
+          label="No, I want to keep it private"
+          variant="secondary"
+          (onClick)="setPrivate()"
+        />
+        <app-button label="Yes, let the world know!" (onClick)="setPublic()" />
+      </nav>
+    </form>
   `,
-  styles: ``
 })
 export class VisibilityComponent {
+  editor = inject(CapsuleEditorService);
 
+  setPrivate() {
+    this.editor.form.controls.visibility.setValue('private');
+    this.editor.next();
+  }
+
+  setPublic() {
+    this.editor.form.controls.visibility.setValue('public');
+    this.editor.next();
+  }
 }


### PR DESCRIPTION
closes #246 

- move `title` signal to `CapsuleEditorService`
- render visibility page with buttons